### PR TITLE
Multiple secrets on the same file

### DIFF
--- a/cmd/pouch/main.go
+++ b/cmd/pouch/main.go
@@ -60,7 +60,7 @@ func main() {
 
 	vault := vault.New(pouchfile.Vault)
 
-	p := pouch.NewPouch(state, vault, pouchfile.Secrets, pouchfile.Notifiers)
+	p := pouch.NewPouch(state, vault, pouchfile.Secrets, pouchfile.Files, pouchfile.Notifiers)
 
 	systemd := systemd.New(pouchfile.Systemd.Configurer())
 	if systemd.IsAvailable() && systemd.CanNotify() {

--- a/pouchfile.go
+++ b/pouchfile.go
@@ -34,6 +34,7 @@ type Pouchfile struct {
 	Systemd   SystemdConfig             `json:"systemd,omitempty"`
 	Notifiers map[string]NotifierConfig `json:"notifiers,omitempty"`
 	Secrets   map[string]SecretConfig   `json:"secrets,omitempty"`
+	Files     []FileConfig              `json:"files,omitempty"`
 }
 
 type SystemdConfig struct {
@@ -60,7 +61,6 @@ type SecretConfig struct {
 	VaultURL   string                 `json:"vault_url,omitempty"`
 	HTTPMethod string                 `json:"http_method,omitempty"`
 	Data       map[string]interface{} `json:"data,omitempty"`
-	Files      []FileConfig           `json:"files,omitempty"`
 }
 
 type FileConfig struct {

--- a/state.go
+++ b/state.go
@@ -46,7 +46,7 @@ type PouchState struct {
 	Secrets map[string]*SecretState `json:"secrets,omitempty"`
 
 	// Path from where this state was read
-	Path string
+	Path string `json:"-"`
 }
 
 func NewState(path string) *PouchState {
@@ -142,6 +142,7 @@ func (s *PouchState) SetSecret(name string, secret *api.Secret) {
 		Name:          name,
 		Timestamp:     time.Now(),
 		LeaseDuration: secret.LeaseDuration,
+		Data:          secret.Data,
 	}
 	if secret.Data != nil {
 		ttlNumber, ok := secret.Data["ttl"].(json.Number)
@@ -209,6 +210,9 @@ type SecretState struct {
 
 	// If the secret has no expiration data, don't try to update it
 	DisableAutoUpdate bool `json:"disable_auto_uptdate,omitempty"`
+
+	// Actual secret
+	Data map[string]interface{} `json:"data,omitempty"`
 }
 
 func (s *SecretState) TimeToUpdate() time.Duration {


### PR DESCRIPTION
After a conversation with @albertobaselga we saw that in some cases we may want to access multiple secrets from the same template. These changes address this issue by separating files and secrets definition.

Summary:
* Now `pouch` keeps all the secrets data in the state. This is needed to execute templates with multiple secrets after only one of the secrets has be renewed. I don't like it so much as it smells to security issues, but state is at least as protected as the rest of secrets written to disk, so it shouldn't create additional issues.
* Pouchfile format changes, now `files` are on first level instead of under each `secret`.
* Secrets in templates have to be accessed with the `secret` function now, this is required to be able to automatically track dependencies between files and secrets. No data is directly passed to templates now.
* As a collateral effect, all files are rewritten and notifiers executed when pouch is restarted, even if no secret has changed. This is done in case some template has changed. As an alternative we might keep a checksum of file in disk and compare.

**These changes are not backwards compatible.**