### PR TITLE
Improve consistency and testability of time to update estimation

### DIFF
--- a/pouch.go
+++ b/pouch.go
@@ -242,7 +242,7 @@ func (p *pouch) Run(ctx context.Context) error {
 		var nextUpdate <-chan time.Time
 		s, ttu := p.State.NextUpdate()
 		if s != nil {
-			nextUpdate = time.After(ttu)
+			nextUpdate = time.After(time.Until(ttu))
 		} else {
 			log.Printf("No secret to update")
 		}

--- a/pouchfile.go
+++ b/pouchfile.go
@@ -58,9 +58,9 @@ func (s *SystemdConfig) Configurer() *systemdConfigurer {
 }
 
 type SecretConfig struct {
-	VaultURL   string                 `json:"vault_url,omitempty"`
-	HTTPMethod string                 `json:"http_method,omitempty"`
-	Data       map[string]interface{} `json:"data,omitempty"`
+	VaultURL   string     `json:"vault_url,omitempty"`
+	HTTPMethod string     `json:"http_method,omitempty"`
+	Data       SecretData `json:"data,omitempty"`
 }
 
 type FileConfig struct {

--- a/state.go
+++ b/state.go
@@ -289,18 +289,19 @@ func (s *SecretState) TTL() (int, bool) {
 	return 0, false
 }
 
-func (s *SecretState) TimeToUpdate() (time.Time, bool) {
+func (s *SecretState) TimeToUpdate() (minTTU time.Time, known bool) {
 	for _, source := range secretTTUSources {
 		ttu, err := source(s)
 		if err != nil {
 			log.Printf("Error trying to obtain TTU for secret '%s': %s", s.Name, err)
 			continue
 		}
-		if ttu != nil {
-			return *ttu, true
+		if ttu != nil && (!known || ttu.Before(minTTU)) {
+			minTTU = *ttu
+			known = true
 		}
 	}
-	return time.Time{}, false
+	return
 }
 
 func (s *SecretState) RegisterUsage(path string, priority int) {

--- a/state_test.go
+++ b/state_test.go
@@ -168,6 +168,14 @@ var secretWithCertificate = &SecretState{Timestamp: time.Time{}, DurationRatio: 
 var secretBeforeCertificate = &SecretState{TTL: 60, Timestamp: testCertNotBefore, DurationRatio: 0.5}
 var secretAfterCertificate = &SecretState{TTL: 60, Timestamp: testCertNotAfter, DurationRatio: 0.5}
 
+var allSecretCases = []*SecretState{
+	secretCaseTTL,
+	unknownTTL,
+	secretWithCertificate,
+	secretBeforeCertificate,
+	secretAfterCertificate,
+}
+
 var nextUpdateCases = []struct {
 	State  PouchState
 	Secret *SecretState
@@ -223,6 +231,16 @@ func TestPouchStateNextUpdate(t *testing.T) {
 		}
 		if foundSecret != nil && foundTTU != c.TTU {
 			t.Fatalf("Case #%d: found TTU %s, expected %s", i, foundTTU, c.TTU)
+		}
+	}
+}
+
+func TestConsistentTTU(t *testing.T) {
+	for _, c := range allSecretCases {
+		firstTTU, firstKnown := c.TimeToUpdate()
+		secondTTU, secondKnown := c.TimeToUpdate()
+		if firstTTU != secondTTU || firstKnown != secondKnown {
+			t.Fatalf("TTU changed after some time for %+v", c)
 		}
 	}
 }

--- a/state_test.go
+++ b/state_test.go
@@ -162,15 +162,31 @@ hwIhAKsZN5/gMTYToF4ZnMy4aKaKMyd/gSkiPudiYb5OYqyfAiB6EXX7DzjCohUa
 5n1aU0/ed9d2
 -----END PRIVATE KEY-----`
 
-var secretCaseTTL = &SecretState{TTL: 360, Timestamp: time.Time{}, DurationRatio: 0.5}
 var unknownTTL = &SecretState{Timestamp: time.Time{}}
-var secretWithCertificate = &SecretState{Timestamp: time.Time{}, DurationRatio: 0.5, Data: map[string]interface{}{"certificate": testCert, "private_key": testKey}}
-var secretBeforeCertificate = &SecretState{TTL: 60, Timestamp: testCertNotBefore, DurationRatio: 0.5}
-var secretAfterCertificate = &SecretState{TTL: 60, Timestamp: testCertNotAfter, DurationRatio: 0.5}
+var secretCaseTTL = &SecretState{
+	Data:          SecretData{"ttl": json.Number("360")},
+	Timestamp:     time.Time{},
+	DurationRatio: 0.5,
+}
+var secretWithCertificate = &SecretState{
+	Data:          SecretData{"certificate": testCert, "private_key": testKey},
+	Timestamp:     time.Time{},
+	DurationRatio: 0.5,
+}
+var secretBeforeCertificate = &SecretState{
+	Data:          SecretData{"ttl": json.Number("60")},
+	Timestamp:     testCertNotBefore,
+	DurationRatio: 0.5,
+}
+var secretAfterCertificate = &SecretState{
+	Data:          SecretData{"ttl": json.Number("60")},
+	Timestamp:     testCertNotAfter,
+	DurationRatio: 0.5,
+}
 
 var allSecretCases = []*SecretState{
-	secretCaseTTL,
 	unknownTTL,
+	secretCaseTTL,
 	secretWithCertificate,
 	secretBeforeCertificate,
 	secretAfterCertificate,


### PR DESCRIPTION
Some changes to do a more consistent estimation of next time to update (TTU), and specially to be able to test it. Changes are specially focused on stop relying on `time.Now()`.

_TTU could be defined before these changes as the time since "now" to the time of renovation, what is obviously different depending on the moment of the calculation. After these changes the TTU is the specific point in time of renovation, that doesn't depend on any other thing_ 

- [x] Add some tests with some basic cases
- [x] Operate as much as possible with the specific time instead of with the duration since it was calculated as it can be inconsistent, specially on tests
- [x] Explicitely report if a TTU for a secret could be calculated instead of just returning "0"
- [x] Base TTU of certificates also on its creation time
- [x] Add some more test cases for certificates in general