### PR TITLE
Add priority param ordering

### DIFF
--- a/cmd/pouch/README.md
+++ b/cmd/pouch/README.md
@@ -95,6 +95,7 @@ files:
   template_file: <path to file containing a template>
   notify:
   - <notifier>
+  priority: <integer>
   <...>
 ```
 Files to be provisioned using defined secrets. When the file is written, the
@@ -106,6 +107,9 @@ Access to secrets from templates is done by using the `secret` function. This
 function has two arguments, first one the name of the secret and second one
 the key of the value inside the secret.
 Files are automatically updated when a secret they use is requested again.
+Optionally, if it is needed an specific order to update the files, a priority
+could be assigned to each file. The lower the defined priority value,
+the sooner the file will be updated. Default value for priority field is *zero*.
 
 As an example:
 
@@ -126,10 +130,12 @@ files:
   mode: 0600
   template: |
     {{ secret "kubelet_certs" "private_key" }}
+  priority: 10
 - path: /etc/kubernetes/ssl/client.crt
   mode: 0600
   template: |
     {{ secret "kubelet_certs" "certificate" }}
+  priority: 20
 - path: /etc/kubernetes/ssl/ca.crt
   mode: 0600
   template: |

--- a/pouch.go
+++ b/pouch.go
@@ -174,7 +174,7 @@ func (p *pouch) resolveFile(fc FileConfig) error {
 		if !found {
 			return nil, fmt.Errorf("unkown key in secret '%s': %s", name, key)
 		}
-		secret.RegisterUsage(fc.Path)
+		secret.RegisterUsage(fc.Path, fc.Priority)
 		return value, nil
 	}
 
@@ -255,7 +255,7 @@ func (p *pouch) Run(ctx context.Context) error {
 				return err
 			}
 			for _, f := range p.State.Secrets[s.Name].FilesUsing {
-				err = p.resolveFile(p.Files[f])
+				err = p.resolveFile(p.Files[f.Path])
 				if err != nil {
 					return err
 				}

--- a/pouch.go
+++ b/pouch.go
@@ -255,6 +255,7 @@ func (p *pouch) Run(ctx context.Context) error {
 				return err
 			}
 			for _, f := range p.State.Secrets[s.Name].FilesUsing {
+				log.Printf("Updating file '%s'", f.Path)
 				err = p.resolveFile(p.Files[f.Path])
 				if err != nil {
 					return err

--- a/pouchfile.go
+++ b/pouchfile.go
@@ -84,6 +84,7 @@ func LoadPouchfile(path string) (*Pouchfile, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer r.Close()
 	return loadPouchfile(r)
 }
 

--- a/pouchfile.go
+++ b/pouchfile.go
@@ -69,6 +69,7 @@ type FileConfig struct {
 	Template     string   `json:"template,omitempty"`
 	TemplateFile string   `json:"template_file,omitempty"`
 	Notify       []string `json:"notify,omitempty"`
+	Priority     int      `json:"priority,omitempty"`
 }
 
 type NotifierConfig struct {

--- a/pouchfile_test.go
+++ b/pouchfile_test.go
@@ -35,16 +35,16 @@ secrets:
   foo:
     vault_url: /v1/kubernetes-pki/issue/kubelet
     http_method: POST
-    files:
-    - path: /etc/kubernetes/ssl/client.key
-      template: |
-        {{ .private_key }}
-    - path: /etc/kubernetes/ssl/client.crt
-      template: |
-        {{ .certificate }}
-    - path: /etc/kubernetes/ssl/ca.crt
-      template: |
-        {{ .issuing_ca }}
+files:
+  - path: /etc/kubernetes/ssl/client.key
+    template: |
+      {{ .private_key }}
+  - path: /etc/kubernetes/ssl/client.crt
+    template: |
+      {{ .certificate }}
+  - path: /etc/kubernetes/ssl/ca.crt
+    template: |
+      {{ .issuing_ca }}
 `,
 	`
 wrapped_secret_id_path: /var/run/vault_token
@@ -59,14 +59,14 @@ secrets:
   nginx:
     vault_url: /v1/pki/issue/nginx
     http_method: POST
-    files:
-    - path: /etc/nginx/ssl/bundle.crt
-      template: |
-        {{ .certificate }}
-        {{ .issuing_ca }}
-    - path: /etc/nginx/ssl/server.key
-      template: |
-        {{ .private_key }}
+files:
+  - path: /etc/nginx/ssl/bundle.crt
+    template: |
+      {{ .certificate }}
+      {{ .issuing_ca }}
+  - path: /etc/nginx/ssl/server.key
+    template: |
+      {{ .private_key }}
 `,
 }
 

--- a/pouchfile_test.go
+++ b/pouchfile_test.go
@@ -68,6 +68,33 @@ files:
     template: |
       {{ .private_key }}
 `,
+	`
+wrapped_secret_id_path: /var/run/vault_token
+vault:
+  address: http://127.0.0.1:8200
+  role_id: kubelet
+  secret_id: ""
+  token: ""
+systemd:
+  enabled: true
+secrets:
+  nginx:
+    vault_url: /v1/pki/issue/nginx
+    http_method: POST
+files:
+  - path: /etc/kubernetes/ssl/client.key
+    priority: 10
+    template: |
+      {{ .private_key }}
+  - path: /etc/kubernetes/ssl/client.crt
+    priority: 20
+    template: |
+      {{ .certificate }}
+  - path: /etc/kubernetes/ssl/ca.crt
+    priority: 5
+    template: |
+      {{ .issuing_ca }}
+`,
 }
 
 var wrongPouchfile = `

--- a/state.go
+++ b/state.go
@@ -197,7 +197,7 @@ func (s *PouchState) NextUpdate() (secret *SecretState, minTTU time.Duration) {
 	return
 }
 
-type FileSortedList []PriorityFile
+type PriorityFileSortedList []PriorityFile
 
 type PriorityFile struct {
 	Priority int    `json:"-"`
@@ -208,7 +208,7 @@ func (pf *PriorityFile) MarshalJSON() ([]byte, error) {
 	return json.Marshal(pf.Path)
 }
 
-func (s *FileSortedList) UnmarshalJSON(data []byte) error {
+func (s *PriorityFileSortedList) UnmarshalJSON(data []byte) error {
 	var priorityFiles []string
 
 	if err := json.Unmarshal(data, &priorityFiles); err != nil {
@@ -224,9 +224,9 @@ func (s *FileSortedList) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (p FileSortedList) Len() int      { return len(p) }
-func (p FileSortedList) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
-func (p FileSortedList) Less(i, j int) bool {
+func (p PriorityFileSortedList) Len() int      { return len(p) }
+func (p PriorityFileSortedList) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
+func (p PriorityFileSortedList) Less(i, j int) bool {
 	if p[i].Priority != p[j].Priority {
 		return p[i].Priority < p[j].Priority
 	}
@@ -256,7 +256,7 @@ type SecretState struct {
 	Data map[string]interface{} `json:"data,omitempty"`
 
 	// Files using this secret
-	FilesUsing FileSortedList `json:"files_using,omitempty"`
+	FilesUsing PriorityFileSortedList `json:"files_using,omitempty"`
 }
 
 func (s *SecretState) TimeToUpdate() time.Duration {

--- a/state.go
+++ b/state.go
@@ -297,4 +297,5 @@ func (s *SecretState) RegisterUsage(path string, priority int) {
 		}
 	}
 	s.FilesUsing = append(s.FilesUsing, PriorityFile{Priority: priority, Path: path})
+	sort.Sort(s.FilesUsing)
 }

--- a/state_test.go
+++ b/state_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2018 Tuenti Technologies S.L. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pouch
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+var filesUsingCases = []struct {
+	Secret          *SecretState
+	RegisteredFiles *FileSortedList
+	SortedFiles     *FileSortedList
+}{
+	{
+		secretWithFilesUsing,
+		filesUsingPriorities,
+		sortedFilesUsingPriorities,
+	},
+	{
+		secretWithFilesUsing,
+		filesUsingNoPriorities,
+		sortedFilesUsingNoPriorities,
+	},
+}
+
+var filesUsingPriorities = &FileSortedList{
+	PriorityFile{Priority: 10, Path: "/tmp2"},
+	PriorityFile{Priority: 10, Path: "/tmp1"},
+	PriorityFile{Priority: 90, Path: "/tmp3a"},
+	PriorityFile{Path: "/bar"},
+	PriorityFile{Priority: 20, Path: "/tmp3b"},
+}
+
+var sortedFilesUsingPriorities = &FileSortedList{
+	PriorityFile{Path: "/bar"},
+	PriorityFile{Priority: 10, Path: "/tmp1"},
+	PriorityFile{Priority: 10, Path: "/tmp2"},
+	PriorityFile{Priority: 20, Path: "/tmp3b"},
+	PriorityFile{Priority: 90, Path: "/tmp3a"},
+}
+
+var secretWithFilesUsing = &SecretState{
+	Data:       map[string]interface{}{"test_key": "value_secret"},
+	FilesUsing: FileSortedList{},
+}
+
+var filesUsingNoPriorities = &FileSortedList{
+	PriorityFile{Path: "/temp2"},
+	PriorityFile{Path: "/temp1"},
+	PriorityFile{Path: "/tempcc"},
+	PriorityFile{Path: "/tempbb"},
+	PriorityFile{Path: "/other"},
+}
+
+var sortedFilesUsingNoPriorities = &FileSortedList{
+	PriorityFile{Path: "/other"},
+	PriorityFile{Path: "/temp1"},
+	PriorityFile{Path: "/temp2"},
+	PriorityFile{Path: "/tempbb"},
+	PriorityFile{Path: "/tempcc"},
+}
+
+func TestSortingFilesUsing(t *testing.T) {
+
+	var filesUsing FileSortedList
+	for _, c := range filesUsingCases {
+		filesUsing = *c.RegisteredFiles
+		sort.Sort(filesUsing)
+
+		if !reflect.DeepEqual(filesUsing, *c.SortedFiles) {
+			t.Fatalf("Registered files (%+v) are not sorted as expected (%+v)", filesUsing, *c.SortedFiles)
+		}
+	}
+}
+
+func TestFilesUsingBySecrets(t *testing.T) {
+	state, cleanup := newTestState()
+	defer cleanup()
+	state.Secrets = make(map[string]*SecretState)
+
+	for _, c := range filesUsingCases {
+		state.Secrets["foo"] = c.Secret
+		state.Secrets["foo"].FilesUsing = nil
+
+		for _, pf := range *c.RegisteredFiles {
+			state.Secrets["foo"].RegisterUsage(pf.Path, pf.Priority)
+		}
+
+		state.Save()
+
+		jsonSaved, err := json.Marshal(state)
+		if err != nil {
+			t.Fatalf("State saved to file could not be converted to JSON")
+		}
+
+		d, err := ioutil.ReadFile(state.Path)
+		if err != nil {
+			t.Fatalf("State has not been written - %s\n", err)
+		}
+
+		var loadedState PouchState
+		err = json.Unmarshal(d, &loadedState)
+		if err != nil {
+			t.Fatalf("JSON has failures - %s\n", err)
+		}
+
+		jsonLoaded, err := json.Marshal(loadedState)
+		if err != nil {
+			t.Fatalf("State retrieved from file could not be converted to JSON")
+		}
+
+		if string(jsonSaved) != string(jsonLoaded) {
+			t.Fatalf("JSON saved and read are differents\n%s\n%s\n", jsonSaved, jsonLoaded)
+		}
+
+	}
+}

--- a/state_test.go
+++ b/state_test.go
@@ -26,8 +26,8 @@ import (
 
 var filesUsingCases = []struct {
 	Secret          *SecretState
-	RegisteredFiles *FileSortedList
-	SortedFiles     *FileSortedList
+	RegisteredFiles *PriorityFileSortedList
+	SortedFiles     *PriorityFileSortedList
 }{
 	{
 		secretWithFilesUsing,
@@ -41,7 +41,7 @@ var filesUsingCases = []struct {
 	},
 }
 
-var filesUsingPriorities = &FileSortedList{
+var filesUsingPriorities = &PriorityFileSortedList{
 	PriorityFile{Priority: 10, Path: "/tmp2"},
 	PriorityFile{Priority: 10, Path: "/tmp1"},
 	PriorityFile{Priority: 90, Path: "/tmp3a"},
@@ -49,7 +49,7 @@ var filesUsingPriorities = &FileSortedList{
 	PriorityFile{Priority: 20, Path: "/tmp3b"},
 }
 
-var sortedFilesUsingPriorities = &FileSortedList{
+var sortedFilesUsingPriorities = &PriorityFileSortedList{
 	PriorityFile{Path: "/bar"},
 	PriorityFile{Priority: 10, Path: "/tmp1"},
 	PriorityFile{Priority: 10, Path: "/tmp2"},
@@ -59,10 +59,10 @@ var sortedFilesUsingPriorities = &FileSortedList{
 
 var secretWithFilesUsing = &SecretState{
 	Data:       map[string]interface{}{"test_key": "value_secret"},
-	FilesUsing: FileSortedList{},
+	FilesUsing: PriorityFileSortedList{},
 }
 
-var filesUsingNoPriorities = &FileSortedList{
+var filesUsingNoPriorities = &PriorityFileSortedList{
 	PriorityFile{Path: "/temp2"},
 	PriorityFile{Path: "/temp1"},
 	PriorityFile{Path: "/tempcc"},
@@ -70,7 +70,7 @@ var filesUsingNoPriorities = &FileSortedList{
 	PriorityFile{Path: "/other"},
 }
 
-var sortedFilesUsingNoPriorities = &FileSortedList{
+var sortedFilesUsingNoPriorities = &PriorityFileSortedList{
 	PriorityFile{Path: "/other"},
 	PriorityFile{Path: "/temp1"},
 	PriorityFile{Path: "/temp2"},
@@ -80,7 +80,7 @@ var sortedFilesUsingNoPriorities = &FileSortedList{
 
 func TestSortingFilesUsing(t *testing.T) {
 
-	var filesUsing FileSortedList
+	var filesUsing PriorityFileSortedList
 	for _, c := range filesUsingCases {
 		filesUsing = *c.RegisteredFiles
 		sort.Sort(filesUsing)


### PR DESCRIPTION
This PR tries to solve the issue #12 by adding a new field named `priority` to each file. 
This new field should be used in case there is need to specify an order among all files.

- [X] Add new field `priority` to the pouch file and be managed in the state
- [x] Add tests for this new field 
- [x] Add new parameter to the documentation