### PR TITLE
Redistribute vault test code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+
+go:
+  - 1.8.x
+  - 1.9.x
+  - master
+
+script: make bins test

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ aci: $(DOCKER_IMAGE_FILE) $(APPROLE_IMAGE_FILE)
 	docker2aci $(APPROLE_IMAGE_FILE)
 
 test:
-	go test -cover -tags testutils . ./pkg/... ./cmd/...
+	go test -cover . ./pkg/... ./cmd/...
 
 bins: bin/pouch bin/pouchctl bin/terraform-provisioner-vault-secret-id bin/approle-login
 

--- a/pkg/vault/dummy.go
+++ b/pkg/vault/dummy.go
@@ -1,7 +1,5 @@
-// +build testutils
-
 /*
-Copyright 2017 Tuenti Technologies S.L. All rights reserved.
+Copyright 2018 Tuenti Technologies S.L. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,57 +20,8 @@ import (
 	"path"
 	"testing"
 
-	log "github.com/mgutz/logxi/v1"
-
 	"github.com/hashicorp/vault/api"
-	"github.com/hashicorp/vault/builtin/credential/approle"
-	"github.com/hashicorp/vault/helper/logformat"
-	"github.com/hashicorp/vault/logical"
-	"github.com/hashicorp/vault/physical"
-	v "github.com/hashicorp/vault/vault"
 )
-
-// Based on TestCores on github.com/hashicorp/vault
-func NewTestCoreAppRole(t *testing.T) (*v.Core, [][]byte, string) {
-	logLevel := log.LevelError
-	if testing.Verbose() {
-		logLevel = log.LevelTrace
-	}
-	logger := logformat.NewVaultLogger(logLevel)
-	physicalBackend := physical.NewInmem(logger)
-
-	credentialBackends := make(map[string]logical.Factory)
-	credentialBackends["approle"] = approle.Factory
-
-	conf := &v.CoreConfig{
-		Physical:           physicalBackend,
-		CredentialBackends: credentialBackends,
-		DisableMlock:       true,
-		Logger:             logger,
-	}
-	core, err := v.NewCore(conf)
-
-	keys, token := v.TestCoreInit(t, core)
-	for _, key := range keys {
-		if _, err := v.TestCoreUnseal(core, v.TestKeyCopy(key)); err != nil {
-			t.Fatalf("unseal err: %s", err)
-		}
-	}
-
-	sealed, err := core.Sealed()
-	if err != nil {
-		t.Fatalf("err checking seal status: %s", err)
-	}
-	if sealed {
-		t.Fatal("should not be sealed")
-	}
-
-	if err != nil {
-		t.Fatalf("couldn't start core: %v", err)
-	}
-
-	return core, keys, token
-}
 
 func setupAppRole(t *testing.T, name, token, address string, secret bool) string {
 	v := vaultApi{

--- a/pkg/vault/test/testutils.go
+++ b/pkg/vault/test/testutils.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2018 Tuenti Technologies S.L. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"testing"
+
+	log "github.com/mgutz/logxi/v1"
+
+	"github.com/hashicorp/vault/builtin/credential/approle"
+	"github.com/hashicorp/vault/helper/logformat"
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/physical"
+	v "github.com/hashicorp/vault/vault"
+)
+
+// Based on TestCores on github.com/hashicorp/vault
+func NewTestCoreAppRole(t *testing.T) (*v.Core, [][]byte, string) {
+	logLevel := log.LevelError
+	if testing.Verbose() {
+		logLevel = log.LevelTrace
+	}
+	logger := logformat.NewVaultLogger(logLevel)
+	physicalBackend := physical.NewInmem(logger)
+
+	credentialBackends := make(map[string]logical.Factory)
+	credentialBackends["approle"] = approle.Factory
+
+	conf := &v.CoreConfig{
+		Physical:           physicalBackend,
+		CredentialBackends: credentialBackends,
+		DisableMlock:       true,
+		Logger:             logger,
+	}
+	core, err := v.NewCore(conf)
+
+	keys, token := v.TestCoreInit(t, core)
+	for _, key := range keys {
+		if _, err := v.TestCoreUnseal(core, v.TestKeyCopy(key)); err != nil {
+			t.Fatalf("unseal err: %s", err)
+		}
+	}
+
+	sealed, err := core.Sealed()
+	if err != nil {
+		t.Fatalf("err checking seal status: %s", err)
+	}
+	if sealed {
+		t.Fatal("should not be sealed")
+	}
+
+	if err != nil {
+		t.Fatalf("couldn't start core: %v", err)
+	}
+
+	return core, keys, token
+}

--- a/pkg/vault/vault_test.go
+++ b/pkg/vault/vault_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Tuenti Technologies S.L. All rights reserved.
+Copyright 2018 Tuenti Technologies S.L. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,25 +20,13 @@ import (
 	"path"
 	"testing"
 
+	"github.com/tuenti/pouch/pkg/vault/test"
+
 	"github.com/hashicorp/vault/http"
 )
 
-func TestLoginWithoutSecret(t *testing.T) {
-	core, _, token := NewTestCoreAppRole(t)
-	ln, address := http.TestServer(t, core)
-	defer ln.Close()
-
-	v := vaultApi{Address: address}
-	v.RoleID = setupAppRole(t, "test", token, address, false)
-
-	err := v.Login()
-	if err != nil {
-		t.Fatalf("couldn't login: %v", err)
-	}
-}
-
 func TestLogin(t *testing.T) {
-	core, _, token := NewTestCoreAppRole(t)
+	core, _, token := test.NewTestCoreAppRole(t)
 	ln, address := http.TestServer(t, core)
 	defer ln.Close()
 
@@ -69,7 +57,7 @@ func TestLogin(t *testing.T) {
 }
 
 func TestLoginWithWrappedSecret(t *testing.T) {
-	core, _, token := NewTestCoreAppRole(t)
+	core, _, token := test.NewTestCoreAppRole(t)
 	ln, address := http.TestServer(t, core)
 	defer ln.Close()
 
@@ -108,7 +96,7 @@ func TestLoginWithWrappedSecret(t *testing.T) {
 }
 
 func TestRequestWithData(t *testing.T) {
-	core, _, token := NewTestCoreAppRole(t)
+	core, _, token := test.NewTestCoreAppRole(t)
 	ln, address := http.TestServer(t, core)
 	defer ln.Close()
 


### PR DESCRIPTION
Some code in `testutils.go` that is used by some subpackages of pouch needs code from vault that makes it increase the size of the binaries a lot. It was mitigated by adding the `testutils` tag, so a default build doesn't include the extra code, but it made it neccesary to add the tag when running tests. But this is a bit hacky.

This change redistributes this code, so the code that increases the size of the binaries is moved to a different package (./pkg/vault/test) that can be explicitly imported in tests needing it. As is a different package and is included only in tests it doesn't increase the size of the binaries.

Other code that doesn't include so many things has been added to the vault package in the dummy.go file. This can be used by other packages by importing the pkg/vault package.