### PR TITLE
adding vault environment variables

### DIFF
--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -81,6 +81,9 @@ func New(c Config) Vault {
 
 func (v *vaultApi) getClient() (*api.Client, error) {
 	config := api.DefaultConfig()
+	if err := config.ReadEnvironment(); err != nil {
+		return nil, fmt.Errorf("couldn't read config from environment: %v", err)
+	}
 	if v.Address != "" {
 		config.Address = v.Address
 	}


### PR DESCRIPTION
This allows to read default built-in Vault environment variables such as VAULT_SKIP_VERIFY=true, VAULT_CLIENT_CERT, etc