### PR TITLE
Token and secret renovation retries

### DIFF
--- a/cmd/pouchctl/main.go
+++ b/cmd/pouchctl/main.go
@@ -89,7 +89,7 @@ func main() {
 	})
 
 	if showRoleId {
-		s, err := v.Request("GET", path.Join(vault.AppRoleURL, role, "role-id"), nil)
+		s, _, err := v.Request("GET", path.Join(vault.AppRoleURL, role, "role-id"), nil)
 		if err != nil {
 			fmt.Printf("Couldn't get role ID: %s\n", err)
 			os.Exit(-1)
@@ -111,7 +111,7 @@ func main() {
 	}
 
 	options := vault.RequestOptions{WrapTTL: wrapTTL}
-	s, err := v.Request("POST", path.Join(vault.AppRoleURL, role, "secret-id"), &options)
+	s, _, err := v.Request("POST", path.Join(vault.AppRoleURL, role, "secret-id"), &options)
 	if err != nil {
 		fmt.Printf("Couldn't get wrapped secret ID: %s\n", err)
 		os.Exit(-1)

--- a/cmd/terraform-provisioner-vault-secret-id/resource_provisioner.go
+++ b/cmd/terraform-provisioner-vault-secret-id/resource_provisioner.go
@@ -120,7 +120,7 @@ func applyFn(ctx context.Context) error {
 	role := data.Get("role").(string)
 	wrapTTL := data.Get("wrap_ttl").(string)
 	options := vault.RequestOptions{WrapTTL: wrapTTL}
-	s, err := v.Request("POST", path.Join(vault.AppRoleURL, role, "secret-id"), &options)
+	s, _, err := v.Request("POST", path.Join(vault.AppRoleURL, role, "secret-id"), &options)
 	if err != nil {
 		return fmt.Errorf("couldn't get wrapped secret ID: %s", err)
 	}

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -29,6 +29,7 @@ import (
 const (
 	// Token renewal period is its TTL multiplied by this ratio
 	AutoRenewPeriodRatio = 0.5
+	TokenRetryPeriod     = 5 * time.Second
 
 	TokenHeader   = "X-Vault-Token"
 	WrapTTLHeader = "X-Vault-Wrap-Ttl"
@@ -148,7 +149,7 @@ func (v *vaultApi) autoRenewToken() {
 
 			if err != nil {
 				log.Printf("Couldn't obtain token TTL: %s\n", err)
-				next = 1 * time.Second
+				next = TokenRetryPeriod
 				break
 			}
 
@@ -167,7 +168,7 @@ func (v *vaultApi) autoRenewToken() {
 
 			if err != nil {
 				log.Printf("Couldn't renew token: %s\n", err)
-				next = 1 * time.Second
+				next = TokenRetryPeriod
 			} else {
 				state = stateUpdateTTL
 				next = 0

--- a/pouch.go
+++ b/pouch.go
@@ -142,7 +142,7 @@ func resolveData(data map[string]interface{}) map[string]interface{} {
 
 func (p *pouch) resolveSecret(name string, c SecretConfig) error {
 	options := &vault.RequestOptions{Data: resolveData(c.Data)}
-	s, err := p.Vault.Request(c.HTTPMethod, c.VaultURL, options)
+	s, _, err := p.Vault.Request(c.HTTPMethod, c.VaultURL, options)
 	if err != nil {
 		return err
 	}

--- a/pouch.go
+++ b/pouch.go
@@ -31,7 +31,8 @@ import (
 )
 
 const (
-	DefaultFileMode = os.FileMode(0600)
+	DefaultFileMode   = os.FileMode(0600)
+	SecretRetryPeriod = 5 * time.Second
 )
 
 type Pouch interface {
@@ -140,18 +141,31 @@ func resolveData(data map[string]interface{}) map[string]interface{} {
 	return result
 }
 
-func (p *pouch) resolveSecret(name string, c SecretConfig) error {
+func (p *pouch) resolveSecret(name string, c SecretConfig) (retry bool, err error) {
 	options := &vault.RequestOptions{Data: resolveData(c.Data)}
-	s, _, err := p.Vault.Request(c.HTTPMethod, c.VaultURL, options)
+	s, resp, err := p.Vault.Request(c.HTTPMethod, c.VaultURL, options)
 	if err != nil {
-		return err
+		switch {
+		case resp == nil:
+			// Retry if there was a connection error and no response
+			// from server was received
+			return true, err
+		case resp.StatusCode/100 == 5:
+			// If the service is behind a proxy and is unavailable
+			// or if vault is sealed, so keep trying
+			return true, err
+		case resp.StatusCode/100 == 4:
+			// If we have a 400 something is wrong with our request
+			// or our permissions, don't retry
+			return false, err
+		}
 	}
 	p.State.SetSecret(name, s)
 	err = p.State.Save()
 	if err != nil {
 		log.Printf("Couldn't save state: %s", err)
 	}
-	return nil
+	return false, nil
 }
 
 func (p *pouch) resolveFile(fc FileConfig) error {
@@ -209,7 +223,7 @@ func (p *pouch) Run(ctx context.Context) error {
 			// someone has changed
 			s.FilesUsing = nil
 		} else {
-			err = p.resolveSecret(name, c)
+			_, err = p.resolveSecret(name, c)
 			if err != nil {
 				return err
 			}
@@ -250,9 +264,16 @@ func (p *pouch) Run(ctx context.Context) error {
 		select {
 		case <-nextUpdate:
 			log.Printf("Updating secret '%s'", s.Name)
-			err = p.resolveSecret(s.Name, p.Secrets[s.Name])
-			if err != nil {
-				return err
+			for retry := true; retry; {
+				retry, err = p.resolveSecret(s.Name, p.Secrets[s.Name])
+				if err != nil {
+					if retry {
+						log.Println(err)
+						<-time.After(SecretRetryPeriod)
+					} else {
+						return err
+					}
+				}
 			}
 			for _, f := range p.State.Secrets[s.Name].FilesUsing {
 				log.Printf("Updating file '%s'", f.Path)

--- a/pouch_test.go
+++ b/pouch_test.go
@@ -67,7 +67,7 @@ func (v *DummyVault) UnwrapSecretID(token string) error {
 	return nil
 }
 
-func (v *DummyVault) Request(method, urlPath string, options *vault.RequestOptions) (*api.Secret, error) {
+func (v *DummyVault) Request(method, urlPath string, options *vault.RequestOptions) (*api.Secret, *api.Response, error) {
 	if v.Token != v.ExpectedToken {
 		v.T.Fatalf("incorrect token on request")
 	}
@@ -76,7 +76,7 @@ func (v *DummyVault) Request(method, urlPath string, options *vault.RequestOptio
 	if !ok {
 		v.T.Fatal("incorrect response")
 	}
-	return s, nil
+	return s, nil, nil
 }
 
 func (v *DummyVault) GetToken() string {


### PR DESCRIPTION
This issue has gone a bit beyond scope, but this way we have some more tests and I think that a more clean implementation for some things. Intended to fix #11.

Changes here:

- Token renovation refactored as a two-states state machine, one to obtain the new TTL, another one for the renovation. Both are retried forever while the token cannot be confirmed as invalid.
- Request now exposes also the api response, so we can make checks also depending on that (no response == no connection, response and 403 permission denied...).
- Secret resolution is also retried if failed by connectivity issues.

Possible future improvements:

- Retry with exponential backoffs
- Additional tests on autorenovation, this may require more control on this goroutine